### PR TITLE
Fix table of contents links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,4 @@
 highligher: rouge
 markdown: redcarpet
+redcarpet:
+  extensions: ["with_toc_data"]

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -1,31 +1,29 @@
 <ol class='level-1'>
-    <li><a href='{{ site.baseurl }}/docs/0-installation.html'>Gem compatibility</a></li>
+    <li><a href='{{ site.baseurl }}/docs/0-installation.html'>Installation</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/0-installation.html#gemfile'>Gemfile</a></li>
-        <li><a href='{{ site.baseurl }}/docs/0-installation.html#initialize_active_admin'>Initialize Active Admin</a></li>
-        <li><a href='{{ site.baseurl }}/docs/0-installation.html#register_your_models_with_active_admin'>Register your models with Active
-            Admin</a></li>
-        <li><a href='{{ site.baseurl }}/docs/0-installation.html#will_paginate_compatibility'>will_paginate compatibility</a></li>
+        <li><a href='{{ site.baseurl }}/docs/0-installation.html#setting-up-active-admin'>Setting up Active Admin</a></li>
+        <li><a href='{{ site.baseurl }}/docs/0-installation.html#upgrading'>Upgrading</a></li>
+        <li><a href='{{ site.baseurl }}/docs/0-installation.html#gem-compatibility'>Gem Compatibility</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html'>General Configuration</a></li>
     <ol class='level-2'>
         <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#authentication'>Authentication</a></li>
-        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#site_title_options'>Site Title Options</a></li>
-        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#internationalization_i18n'>Internationalization (I18n)</a></li>
+        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#site-title-options'>Site Title Options</a></li>
+        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#internationalization-(i18n)'>Internationalization (I18n)</a></li>
         <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#namespaces'>Namespaces</a></li>
-        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#load_paths'>Load paths</a></li>
+        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#load-paths'>Load paths</a></li>
         <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#comments'>Comments</a></li>
-        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#utility_navigation'>Utility Navigation</a></li>
+        <li><a href='{{ site.baseurl }}/docs/1-general-configuration.html#utility-navigation'>Utility Navigation</a></li>
     </ol>
-    <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html'>Customize The Resource</a></li>
+    <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html'>Working with Resources</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#rename_the_resource'>Rename the Resource</a></li>
-        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#customize_the_namespace'>Customize the Namespace</a></li>
-        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#customize_the_menu'>Customize the Menu</a></li>
-        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#scoping_the_queries'>Scoping the queries</a></li>
-        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#customizing_resource_retrieval'>Customizing resource
+        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#rename-the-resource'>Rename the Resource</a></li>
+        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#customize-the-namespace'>Customize the Namespace</a></li>
+        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#customize-the-menu'>Customize the Menu</a></li>
+        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#scoping-the-queries'>Scoping the queries</a></li>
+        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#customizing-resource-retrieval'>Customizing resource
             retrieval</a></li>
-        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#belongs_to'>Belongs To</a></li>
+        <li><a href='{{ site.baseurl }}/docs/2-resource-customization.html#belongs-to'>Belongs To</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/3-index-pages.html'>Customizing the Index Page</a></li>
     <ol class='level-2'>
@@ -38,60 +36,62 @@
     <li><a href='{{ site.baseurl }}/docs/4-csv-format.html'>Customizing the CSV format</a></li>
     <li><a href='{{ site.baseurl }}/docs/5-forms.html'>Customizing the Form</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/5-forms.html#nested_resources'>Nested Resources</a></li>
-        <li><a href='{{ site.baseurl }}/docs/5-forms.html#displaying_errors'>Displaying Errors</a></li>
+        <li><a href='{{ site.baseurl }}/docs/5-forms.html#default'>Default</a></li>
+        <li><a href='{{ site.baseurl }}/docs/5-forms.html#partials'>Partials</a></li>
+        <li><a href='{{ site.baseurl }}/docs/5-forms.html#nested-resources'>Nested Resources</a></li>
+        <li><a href='{{ site.baseurl }}/docs/5-forms.html#datepicker'>Datepicker</a></li>
+        <li><a href='{{ site.baseurl }}/docs/5-forms.html#displaying-errors'>Displaying Errors</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/6-show-pages.html'>Customize the Show Page</a></li>
     <li><a href='{{ site.baseurl }}/docs/7-sidebars.html'>Sidebar Sections</a></li>
     <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html'>Custom Controller Actions</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#collection_actions'>Collection Actions</a></li>
-        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#member_actions'>Member Actions</a></li>
-        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#controller_action_http_verb'>Controller Action HTTP Verb</a></li>
-        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#rendering_in_custom_actions'>Rendering in Custom Actions</a></li>
-        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#modify_the_controller'>Modify the Controller</a></li>
+        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#collection-actions'>Collection Actions</a></li>
+        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#member-actions'>Member Actions</a></li>
+        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#http-verbs'>HTTP Verbs</a></li>
+        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#rendering'>Rendering</a></li>
+        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#action-items'>Action Items</a></li>
+        <li><a href='{{ site.baseurl }}/docs/8-custom-actions.html#modifying-the-controller'>Modifying the Controller</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/9-batch-actions.html'>Index Batch Actions</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/9-batch-actions.html#provided_batch_action'>Provided Batch Action</a></li>
-        <li><a href='{{ site.baseurl }}/docs/9-batch-actions.html#creating_your_own_batch_actions'>Creating Your Own Batch Actions</a></li>
+        <li><a href='{{ site.baseurl }}/docs/9-batch-actions.html#provided-batch-action'>Provided Batch Action</a></li>
+        <li><a href='{{ site.baseurl }}/docs/9-batch-actions.html#creating-your-own'>Creating Your Own</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html'>Custom Pages</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#available_features'>Available Features</a></li>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#create_a_new_page'>Create a new Page</a></li>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#page_title__i18n'>Page Title & I18n</a></li>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#customize_the_menu'>Customize the Menu</a></li>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#add_a_sidebar_section'>Add a Sidebar Section</a></li>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#add_an_action_item'>Add an Action Item</a></li>
-        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#add_a_page_action'>Add a Page Action</a></li>
+        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#create-a-new-page'>Create a new Page</a></li>
+        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#customize-the-menu'>Customize the Menu</a></li>
+        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#add-a-sidebar'>Add a Sidebar</a></li>
+        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#add-an-action-item'>Add an Action Item</a></li>
+        <li><a href='{{ site.baseurl }}/docs/10-custom-pages.html#add-a-page-action'>Add a Page Action</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/11-decorators.html'>Decorators</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/11-decorators.html#configuration'>Configuration</a></li>
-        <li><a href='{{ site.baseurl }}/docs/11-decorators.html#example_usage'>Example Usage</a></li>
+        <li><a href='{{ site.baseurl }}/docs/11-decorators.html#example-usage'>Example Usage</a></li>
         <li><a href='{{ site.baseurl }}/docs/11-decorators.html#forms'>Forms</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html'>Arbre Components</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#text_node'>Text Node</a></li>
+        <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#text-node'>Text Node</a></li>
         <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#panels'>Panels</a></li>
         <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#columns'>Columns</a></li>
-        <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#table_for'>Table For</a></li>
-        <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#status_tag'>Status tag</a></li>
+        <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#table-for'>Table For</a></li>
+        <li><a href='{{ site.baseurl }}/docs/12-arbre-components.html#status-tag'>Status tag</a></li>
     </ol>
     <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html'>Authorization Adapter</a></li>
     <ol class='level-2'>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#setting_up_your_own_authorizationadapter'>Setting up your own
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#setting-up-your-own-authorizationadapter'>Setting up your own
             AuthorizationAdapter</a></li>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#getting_access_to_the_current_user'>Getting Access to the
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#getting-access-to-the-current-user'>Getting Access to the
             Current User</a></li>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#scoping_collections_in_authorization_adapters'>Scoping
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#scoping-collections-in-authorization-adapters'>Scoping
             Collections in Authorization Adapters</a></li>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#managing_access_to_pages'>Managing Access to Pages</a></li>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#action_types'>Action Types</a></li>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#checking_for_authorization_in_controllers_and_views'>Checking
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#managing-access-to-pages'>Managing Access to Pages</a></li>
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#action-types'>Action Types</a></li>
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#checking-for-authorization-in-controllers-and-views'>Checking
             for Authorization in Controllers and Views</a></li>
-        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#using_the_cancan_adapter'>Using the CanCan Adapter</a></li>
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#using-the-cancan-adapter'>Using the CanCan Adapter</a></li>
+        <li><a href='{{ site.baseurl }}/docs/13-authorization-adapter.html#using-the-pundit-adapter'>Using the Pundit Adapter</a></li>
     </ol>
 </ol>


### PR DESCRIPTION
Enable redcarpet's `with_toc_data` to generate id attributes for header tags. Also, update the table of contents to reflect changes in the documentation.