### PR TITLE
Fix double-brace causing Jekyll to hide content

### DIFF
--- a/docs/9-batch-actions.md
+++ b/docs/9-batch-actions.md
@@ -148,7 +148,7 @@ When you have dynamic form inputs you can pass a proc instead:
 
 ```ruby
 # NOTE: multi-pluck is new to Rails 4
-batch_action :doit, form: ->{{user: User.pluck(:name, :id)}} do |ids, inputs|
+batch_action :doit, form: -> { {user: User.pluck(:name, :id)} } do |ids, inputs|
   User.find(inputs[:user])
   # ...
 end


### PR DESCRIPTION
The double-brace causes Jekyll to replace the content with nothing, since it can't be evaluated.

Following the [Ruby style guide](https://github.com/bbatsov/ruby-style-guide#stabby-lambda-with-args), I inserted spaces inside the lambda braces, which happens to fix the Jekyll problem anyway.