### PR TITLE
Update links on Custom Pages site

### DIFF
--- a/docs/10-custom-pages.md
+++ b/docs/10-custom-pages.md
@@ -50,11 +50,11 @@ end
 
 ## Customize the Menu
 
-See the [Menu](2-resource-customization.md#customize-the-menu) documentation.
+See the [Menu](/docs/2-resource-customization.md#customize-the-menu) documentation.
 
 ## Add a Sidebar
 
-See the [Sidebars](7-sidebars.md) documentation.
+See the [Sidebars](/docs/7-sidebars.md) documentation.
 
 ## Add an Action Item
 


### PR DESCRIPTION
The links for "Menu" and "Sidebars" were not pointing to the actual documents.